### PR TITLE
fix: close bracket fix

### DIFF
--- a/docs/content/tools/importers/oapi3.md
+++ b/docs/content/tools/importers/oapi3.md
@@ -3,7 +3,7 @@ title: OpenAPI3
 weight: 2
 ---
 
-Presidium includes a Golang tool ([presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3) for importing your OpenAPI 3 spec into Presidium documentation.
+Presidium includes a Golang tool ([presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3)) for importing your OpenAPI 3 spec into Presidium documentation.
 
 1. Add the [presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3) dependency to your site's `package.json` or run `npm install --save presidium-oapi3`.
 1. Add a script that invokes the tool.


### PR DESCRIPTION
Fix: Close bracket in the Open API 3 article. 

Before:
<img width="890" alt="image" src="https://github.com/user-attachments/assets/91c8a8b0-5c97-4f4f-b43d-16a2ba75f42a">

Test: 
Go to tools > importers  > OpenApi3
See that it no longer reads as:
Presidium includes a Golang tool ([presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3) for importing your OpenAPI 3 spec into Presidium documentation.
But rather:
Presidium includes a Golang tool ([presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3)) for importing your OpenAPI 3 spec into Presidium documentation.