### PR TITLE
feat: update themes to separation of concerns

### DIFF
--- a/docs/config.yml
+++ b/docs/config.yml
@@ -82,8 +82,8 @@ outputs:
   - SearchMap
 module:
   imports:
-  - path: github.com/spandigital/presidium-theme-website
-    disabled: false
+  - path: github.com/spandigital/presidium-styling-base
+  - path: github.com/spandigital/presidium-layouts-base
 enableInlineShortcodes: true
 frontmatter:
   lastmod:

--- a/docs/content/recipes/scopes/scopes.md
+++ b/docs/content/recipes/scopes/scopes.md
@@ -1,3 +1,8 @@
+---
+title: Scoped Presidium Sites Continued
+draft: true
+---
+
 Presidium allows content creators to scope the final site specific audiences. For example: _internal_, _public_, _customer_, or even something such as _head-office_. Presidium will take care of excluding/including only relevant articles and sections from the final site.
 
 It is both possible to scope articles and the menu segments by adding the appropriate front matter.

--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,7 @@ module presidium
 
 go 1.18
 
-require github.com/spandigital/presidium-theme-website v2.17.13+incompatible // indirect
+require (
+	github.com/spandigital/presidium-layouts-base v0.1.23 // indirect
+	github.com/spandigital/presidium-styling-base v0.1.16 // indirect
+)


### PR DESCRIPTION
# feat: update themes to separation of concerns

changed config.yml
updated go.mod to reflect the latest versions
added the latest makefile

Confirmed index page still loaded correctly, but subsequent docs will use the latest themes.
![Screenshot 2024-12-19 at 17 50 48](https://github.com/user-attachments/assets/169a1275-4555-4857-a7d9-79f455ed8f5b)

![Screenshot 2024-12-19 at 17 51 09](https://github.com/user-attachments/assets/7e1497b0-5ef6-4636-98c5-17f4376a7579)

