### PR TITLE
Simplified installation commands

### DIFF
--- a/docs/layouts/index.html
+++ b/docs/layouts/index.html
@@ -106,7 +106,7 @@
                     <p class="title">Up and running in minutes...</p>
                     <div class="term">
                         <p><span class="cmd-1">$ </span><span class="cmd-2">brew </span><span class="cmd-3">tap </span><span
-                                class="cmd-4">SPANDigital/homebrew-tap git@github.com:SPANDigital/homebrew-tap.git</span></p>
+                                class="cmd-4">SPANDigital/homebrew-tap</span></p>
                         <p><span class="cmd-1">$ </span><span class="cmd-2">brew </span><span class="cmd-3">install presidium</span></p>
                         <p><span class="cmd-1">$ </span><span class="cmd-2">presidium </span><span
                                 class="cmd-3">init </span></p>


### PR DESCRIPTION
This PR simplifies the installation command as Presidium is a public repo, it does not require the long version. This will make it more friendly on the eye on the website.

Simplified installation commands:

```brew tap SPANDigital/homebrew-tap```

```brew install presidium```