### PR TITLE
chore: PRSDM-7947 (Replace NPM install with brew for presidium-oapi3)

### DIFF
--- a/docs/content/tools/importers/oapi3.md
+++ b/docs/content/tools/importers/oapi3.md
@@ -3,7 +3,7 @@ title: OpenAPI3
 weight: 2
 ---
 
-Presidium includes a Golang tool ([presidium-oapi3](https://formulae.brew.sh/formula/presidium-oapi3)) for importing your OpenAPI 3 spec into Presidium documentation.
+Presidium includes a Golang tool ([presidium-oapi3](https://github.com/SPANDigital/presidium-oapi3)) for importing your OpenAPI 3 spec into Presidium documentation.
 
 1. Install the [presidium-oapi3](https://github.com/SPANDigital/presidium-oapi3) tool using Homebrew:
 

--- a/docs/content/tools/importers/oapi3.md
+++ b/docs/content/tools/importers/oapi3.md
@@ -3,32 +3,27 @@ title: OpenAPI3
 weight: 2
 ---
 
-Presidium includes a Golang tool ([presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3)) for importing your OpenAPI 3 spec into Presidium documentation.
+Presidium includes a Golang tool ([presidium-oapi3](https://formulae.brew.sh/formula/presidium-oapi3)) for importing your OpenAPI 3 spec into Presidium documentation.
 
-1. Add the [presidium-oapi3](https://www.npmjs.com/package/presidium-oapi-3) dependency to your site's `package.json` or run `npm install --save presidium-oapi3`.
-1. Add a script that invokes the tool.
-1. Run `npm run import-oapi` whenever you need to update your API documentation.
+1. Install the [presidium-oapi3](https://github.com/SPANDigital/presidium-oapi3) tool using Homebrew:
 
-```json
-{
-    "scripts" : {
-        "import-oapi" : "presidium-oapi3"
-    },
-}
+   ```sh
+   brew tap SPANDigital/homebrew-tap https://github.com/SPANDigital/homebrew-tap.git
+   brew install presidium-oapi3
 ```
 
 Example:
 
 ```sh
-$ npm run import-oapi convert -f <YOUR_API_SPEC> -o <THE_OUTPUT_DIRECTORY> -r <THE_PRESIDIUM_REFERENCE_URL>
+$ presidium-oapi3 convert -f <YOUR_API_SPEC> -o <THE_OUTPUT_DIRECTORY> -r <THE_PRESIDIUM_REFERENCE_URL>
 ```
 
 The following options are available for `presidium-oapi3`:
 
-| Option | Description
-|:-------|:---
-|  -n, \--apiName `string`       | The name under which the generated docs will be grouped |
-|  -f, \--file `string`         |  OpenAPI 3 spec file |
-|  -o, \--outputDir `string`     | The output directory |
-|  -r, \--referenceURL `string`  | The reference URL (default "reference")|
-|  -h, \--help                 | help for convert |
+| Option                       | Description                                             |
+|:-----------------------------|:--------------------------------------------------------|
+| -n, \--apiName `string`      | The name under which the generated docs will be grouped |
+| -f, \--file `string`         | OpenAPI 3 spec file                                     |
+| -o, \--outputDir `string`    | The output directory                                    |
+| -r, \--referenceURL `string` | The reference URL (default "reference")                 |
+| -h, \--help                  | help for convert                                        |

--- a/docs/content/tools/importers/oapi3.md
+++ b/docs/content/tools/importers/oapi3.md
@@ -7,7 +7,7 @@ Presidium includes a Golang tool ([presidium-oapi3](https://formulae.brew.sh/for
 
 1. Install the [presidium-oapi3](https://github.com/SPANDigital/presidium-oapi3) tool using Homebrew:
 
-   ```sh
+```sh
    brew tap SPANDigital/homebrew-tap https://github.com/SPANDigital/homebrew-tap.git
    brew install presidium-oapi3
 ```


### PR DESCRIPTION
Update open source doc to use `brew` instead of `npm` as npm is currently not working:

<img width="778" alt="image" src="https://github.com/user-attachments/assets/dcb70bfe-3097-44ff-9ca9-48614746b9e6" />

## Ticket

[PRSDM-7947](https://spandigital.atlassian.net/browse/PRSDM-7947)