### PR TITLE
feat: PRSDM-10268 enforce imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Since we require the embedded Hugo version to be built into a binary, some of th
 
 ## Getting started
 
+Initialize the theme submodules before building or running tests:
+```
+git submodule update --init --recursive
+```
+
 Run the build command:
 ```
 make build

--- a/pkg/configtranslation/configfile.go
+++ b/pkg/configtranslation/configfile.go
@@ -210,6 +210,18 @@ func ReadJekyllConfig(path string) (*JekyllConfig, error) {
 	return config, nil
 }
 
+func ReadHugoConfig(path string) (*HugoConfig, error) {
+	b, err := filesystem.AFS.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	cfg := &HugoConfig{}
+	if err := yaml.Unmarshal(b, cfg); err != nil {
+		return nil, err
+	}
+	return cfg, nil
+}
+
 func WriteHugoConfig(path string, config *HugoConfig) error {
 	b, err := yaml.Marshal(config)
 	if err != nil {

--- a/pkg/domain/service/hugo/hugo.go
+++ b/pkg/domain/service/hugo/hugo.go
@@ -66,7 +66,7 @@ func (s Service) Execute(args ...string) error {
 // Returns an empty string if neither config.yaml nor config.yml exists.
 func configPath() string {
 	for _, name := range []string{"config.yaml", "config.yml"} {
-		if _, err := os.Stat(name); err == nil {
+		if _, err := filesystem.AFS.Stat(name); err == nil {
 			return name
 		}
 	}
@@ -88,9 +88,13 @@ func validateModuleImportOrder(configFile string) error {
 	for i, imp := range cfg.Module.Imports {
 		switch imp.Path {
 		case moduleStylingBase:
-			stylingIdx = i
+			if stylingIdx == -1 {
+				stylingIdx = i
+			}
 		case moduleLayoutsBase:
-			layoutsIdx = i
+			if layoutsIdx == -1 {
+				layoutsIdx = i
+			}
 		}
 	}
 
@@ -100,9 +104,10 @@ func validateModuleImportOrder(configFile string) error {
 
 	if layoutsIdx < stylingIdx {
 		return fmt.Errorf(
-			"invalid module import order: %q (index %d) must come before %q (index %d); fix config.yaml by listing %s before %s",
+			"invalid module import order: %q (index %d) must come before %q (index %d); fix %s by listing %s before %s",
 			moduleStylingBase, stylingIdx,
 			moduleLayoutsBase, layoutsIdx,
+			configFile,
 			moduleStylingBase, moduleLayoutsBase,
 		)
 	}

--- a/pkg/domain/service/hugo/hugo.go
+++ b/pkg/domain/service/hugo/hugo.go
@@ -100,8 +100,7 @@ func validateModuleImportOrder(configFile string) error {
 
 	if layoutsIdx < stylingIdx {
 		return fmt.Errorf(
-			"invalid module import order: %q (index %d) must come before %q (index %d).\n"+
-				"Fix config.yaml: list %s before %s.",
+			"invalid module import order: %q (index %d) must come before %q (index %d); fix config.yaml by listing %s before %s",
 			moduleStylingBase, stylingIdx,
 			moduleLayoutsBase, layoutsIdx,
 			moduleStylingBase, moduleLayoutsBase,

--- a/pkg/domain/service/hugo/hugo.go
+++ b/pkg/domain/service/hugo/hugo.go
@@ -4,10 +4,16 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/SPANDigital/presidium-hugo/pkg/configtranslation"
 	"github.com/SPANDigital/presidium-hugo/pkg/domain/service/themes"
 	"github.com/SPANDigital/presidium-hugo/pkg/filesystem"
 	"github.com/SPANDigital/presidium-hugo/pkg/log"
 	"github.com/gohugoio/hugo/commands"
+)
+
+const (
+	moduleStylingBase = "github.com/spandigital/presidium-styling-base"
+	moduleLayoutsBase = "github.com/spandigital/presidium-layouts-base"
 )
 
 type Service struct {
@@ -48,6 +54,59 @@ func (s Service) Execute(args ...string) error {
 	// Set environment variable to point Hugo to local themes
 	os.Setenv("HUGO_MODULE_REPLACEMENTS", replacements)
 
+	if err := validateModuleImportOrder(configPath()); err != nil {
+		return err
+	}
+
 	// Execute Hugo with local themes - return the error to preserve Hugo's exit behavior
 	return commands.Execute(args)
+}
+
+// configPath returns the path to the Hugo config file in the working directory.
+// Returns an empty string if neither config.yaml nor config.yml exists.
+func configPath() string {
+	for _, name := range []string{"config.yaml", "config.yml"} {
+		if _, err := os.Stat(name); err == nil {
+			return name
+		}
+	}
+	return ""
+}
+
+// validateModuleImportOrder checks that presidium-styling-base appears before
+// presidium-layouts-base in the Hugo module imports. Returns nil when either
+// module is absent — no opinion on configs that do not use both.
+// Config read errors are silently ignored; Hugo will report them downstream.
+func validateModuleImportOrder(configFile string) error {
+	cfg, err := configtranslation.ReadHugoConfig(configFile)
+	if err != nil {
+		return nil
+	}
+
+	stylingIdx := -1
+	layoutsIdx := -1
+	for i, imp := range cfg.Module.Imports {
+		switch imp.Path {
+		case moduleStylingBase:
+			stylingIdx = i
+		case moduleLayoutsBase:
+			layoutsIdx = i
+		}
+	}
+
+	if stylingIdx == -1 || layoutsIdx == -1 {
+		return nil
+	}
+
+	if layoutsIdx < stylingIdx {
+		return fmt.Errorf(
+			"invalid module import order: %q (index %d) must come before %q (index %d).\n"+
+				"Fix config.yaml: list %s before %s.",
+			moduleStylingBase, stylingIdx,
+			moduleLayoutsBase, layoutsIdx,
+			moduleStylingBase, moduleLayoutsBase,
+		)
+	}
+
+	return nil
 }

--- a/pkg/domain/service/hugo/hugo_test.go
+++ b/pkg/domain/service/hugo/hugo_test.go
@@ -3,6 +3,7 @@ package hugo
 import (
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"unsafe"
 
@@ -171,6 +172,75 @@ func TestExecute_WithThemesExtraction(t *testing.T) {
 	// Version command should always work
 	if err != nil {
 		t.Logf("Hugo version command error: %v", err)
+	}
+}
+
+func TestValidateModuleImportOrder(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{
+			name: "correct order",
+			yaml: "module:\n  imports:\n    - path: github.com/spandigital/presidium-styling-base\n    - path: github.com/spandigital/presidium-layouts-base",
+		},
+		{
+			name:    "incorrect order",
+			yaml:    "module:\n  imports:\n    - path: github.com/spandigital/presidium-layouts-base\n    - path: github.com/spandigital/presidium-styling-base",
+			wantErr: true,
+		},
+		{
+			name: "only styling-base present",
+			yaml: "module:\n  imports:\n    - path: github.com/spandigital/presidium-styling-base",
+		},
+		{
+			name: "only layouts-base present",
+			yaml: "module:\n  imports:\n    - path: github.com/spandigital/presidium-layouts-base",
+		},
+		{
+			name: "neither module present",
+			yaml: "module:\n  imports:\n    - path: github.com/spandigital/some-other-module",
+		},
+		{
+			name:    "config file missing",
+			yaml:    "",
+			wantErr: false,
+		},
+		{
+			name: "additional modules interspersed, correct order",
+			yaml: "module:\n  imports:\n    - path: github.com/spandigital/other\n    - path: github.com/spandigital/presidium-styling-base\n    - path: github.com/spandigital/another\n    - path: github.com/spandigital/presidium-layouts-base",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var configFile string
+			if tt.name == "config file missing" {
+				configFile = "/nonexistent/path/config.yaml"
+			} else {
+				f, err := os.CreateTemp(t.TempDir(), "config*.yaml")
+				if err != nil {
+					t.Fatal(err)
+				}
+				_, _ = f.WriteString(tt.yaml)
+				_ = f.Close()
+				configFile = f.Name()
+			}
+
+			err := validateModuleImportOrder(configFile)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateModuleImportOrder() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if err != nil && tt.wantErr {
+				if !strings.Contains(err.Error(), moduleStylingBase) {
+					t.Errorf("error should name the styling module, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), moduleLayoutsBase) {
+					t.Errorf("error should name the layouts module, got: %v", err)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/domain/service/hugo/hugo_test.go
+++ b/pkg/domain/service/hugo/hugo_test.go
@@ -223,8 +223,12 @@ func TestValidateModuleImportOrder(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				_, _ = f.WriteString(tt.yaml)
-				_ = f.Close()
+				if _, err := f.WriteString(tt.yaml); err != nil {
+					t.Fatalf("failed to write temp config file: %v", err)
+				}
+				if err := f.Close(); err != nil {
+					t.Fatalf("failed to close temp config file: %v", err)
+				}
 				configFile = f.Name()
 			}
 


### PR DESCRIPTION
## Description

Enforce imports in the correct order

## How to Test

1. Build the package

2. In a Presidium module, set the order in reverse

3. Run `presidium hugo` against this module (reference the absolute path from your module)

```bash
$ presidium hugo

ERRO[0000] invalid module import order: "github.com/spandigital/presidium-styling-base"
(index 1) must come before "github.com/spandigital/presidium-layouts-base" (index 0).

Fix config.yaml: list github.com/spandigital/presidium-styling-base before 
github.com/spandigital/presidium-layouts-base.  file="presidium/cmd/hugo.go:23"
```

4. Correct the order: base before layouts

5. Run `presidium hugo` against this module

```bash
$ presidium hugo

Start building sites …
...

```

---

## Ticket

https://spandigital.atlassian.net/browse/PRSDM-9466